### PR TITLE
Extended discovery URL functionality with support for local Plex implementations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,7 @@ RUN pip install -e . --no-cache-dir
 
 COPY --from=build /app/dist frontend
 
+COPY entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+RUN chmod +x /docker-entrypoint.d/entrypoint.sh
+
 COPY unit-nginx-config.json /docker-entrypoint.d/config.json

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you'd prefer to self-host Plexio, you can do so easily using Docker. Follow t
 * *REDIS_URL*: URL for a Redis instance if you use `redis` cache (default: `redis://redis:6399/0`).
 * *PLEX_MATCHING_TOKEN*: Auth token for Plex media matching (default: `None`).
 * *SENTRY_DSN*: DSN for error tracking with Sentry (default: `None`).
+* *LOCAL_DISCOVERY*: Show local network Plex server addresses (default: `false`).
 
 ### Using addon with shared Plex server
 If you are using Plexio with a Plex server that you do not own (you will see a "shared" badge 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+cat <<EOF > /app/frontend/env-config.js
+window.env = {
+  VITE_LOCAL_DISCOVERY: "${LOCAL_DISCOVERY}"
+};
+EOF
+
+exec "$@"

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="/env-config.js"></script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/frontend/src/components/configurationForm/fields/discoveryUrl.tsx
+++ b/frontend/src/components/configurationForm/fields/discoveryUrl.tsx
@@ -76,21 +76,28 @@ export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
                   <SelectValue placeholder="Select a discovery url" />
                 </SelectTrigger>
               </FormControl>
-              {server.connections.filter((conn: any) => !conn.local).length >
-                0 && (
+              {server.connections.length > 0 && (
                 <SelectContent>
-                  {server.connections
-                    .filter((conn: any) => !conn.local)
-                    .map((conn: any, index: number) => (
-                      <SelectItem key={index} value={conn.uri}>
-                        {conn.relay && (
-                          <Badge className="mr-1.5" variant="secondary">
-                            relay
-                          </Badge>
-                        )}
-                        {`${conn.address}:${conn.port}`}
-                      </SelectItem>
-                    ))}
+                  {server.connections.map((conn: any, index: number) => (
+                    <SelectItem key={index} value={conn.uri}>
+                      {conn.local && (
+                        <Badge className="mr-1.5" variant="secondary">
+                          local
+                        </Badge>
+                      )}
+                      {conn.relay && (
+                        <Badge className="mr-1.5" variant="secondary">
+                          relay
+                        </Badge>
+                      )}
+                      {!conn.local && !conn.relay && (
+                        <Badge className="mr-1.5" variant="secondary">
+                          public
+                        </Badge>
+                      )}
+                      {`${conn.address}:${conn.port}`}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               )}
             </Select>
@@ -108,7 +115,7 @@ export const DiscoveryUrlField: FC<Props> = ({ form, server }) => {
             </Button>
           </div>
           <FormDescription>
-            Select the public URL of your Plex server.
+            Select the public or local URL of your Plex server.
           </FormDescription>
           <FormMessage />
         </FormItem>

--- a/frontend/vite-env.d.ts
+++ b/frontend/vite-env.d.ts
@@ -1,1 +1,21 @@
-declare const __APP_VERSION__: string
+/// <reference types="vite/client" />
+
+declare global {
+  const __APP_VERSION__: string;
+
+  interface ImportMetaEnv {
+    readonly VITE_LOCAL_DISCOVERY: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
+
+  interface Window {
+    env: {
+      VITE_LOCAL_DISCOVERY: string;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
Added the ability to include local discovery URLs, enabling support for Plex implementations without external-facing IPs or relay connections. Enhanced the discovery URL selection box with badges indicating connection types: local, relay, and public.