### PR TITLE
Populate behaviorHints.filename on stream objects

### DIFF
--- a/plexio/models/plex.py
+++ b/plexio/models/plex.py
@@ -218,7 +218,7 @@ class PlexMediaMeta(BaseModel):
                         },
                     ),
                     subtitles=external_subtitles,
-                    behaviorHints={'bingeGroup': quality_description},
+                    behaviorHints={'bingeGroup': quality_description, 'filename': filename},
                 ),
             )
 
@@ -250,7 +250,7 @@ class PlexMediaMeta(BaseModel):
                         ),
                         url=str(transcode_url % {'videoQuality': 100}),
                         subtitles=external_subtitles,
-                        behaviorHints={'bingeGroup': quality_description},
+                        behaviorHints={'bingeGroup': quality_description, 'filename': filename},
                     ),
                 )
 
@@ -270,7 +270,7 @@ class PlexMediaMeta(BaseModel):
                             ),
                             url=str(transcode_url % quality_params['plex_args']),
                             subtitles=external_subtitles,
-                            behaviorHints={'bingeGroup': quality_description},
+                            behaviorHints={'bingeGroup': quality_description, 'filename': filename},
                         ),
                     )
 

--- a/plexio/models/stremio.py
+++ b/plexio/models/stremio.py
@@ -55,6 +55,8 @@ class StremioStreamBehaviorHints(StremioBase):
     not_web_ready: bool = False
     binge_group: str | None = None
     proxy_headers: dict | None = None
+    filename: str | None = None  # For client-side release fingerprinting (IntroDB, etc.)
+    video_size: int | None = None  # Stremio-standard byte size of the underlying file
 
 
 class StremioStream(StremioBase):


### PR DESCRIPTION
## What

Populates `behaviorHints.filename` on all stream objects returned by `get_stremio_streams()`, using the same filename that's already extracted from the Plex Part object for use inside the stream `description`.

## Why

`behaviorHints.filename` is the [Stremio-standard field](https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/stream.md#additional-properties-to-provide-information--behaviour-flags) that clients read for machine-readable release identification. It's used by:

- Community skip intro / IntroDB integrations (Nuvio and others)
- Trakt scrobbling for filename-based matching
- OpenSubtitles hash lookup
- Library clients that want to display the release name alongside the stream label

Other Stremio-standard addons (AIOStreams, Torrentio) already populate this field, which means Plex-backed content served via Plexio missed out on these client features despite having the exact same underlying release metadata.

## How

Three changes, all additive:

1. Add `filename: str | None = None` and `video_size: int | None = None` to `StremioStreamBehaviorHints` in `plexio/models/stremio.py` (Stremio-standard optional fields).
2. Populate `filename` on all three stream construction sites in `plexio/models/plex.py`: Direct Play, Transcode Original, Transcode Down. The `filename` variable already exists in scope a few lines above each construction site.

`video_size` is added to the model for completeness but not populated in this PR (would need a guarded `.get()` on `media['Part'][0]`; happy to follow up with that in a second PR if desired).

## Compatibility

- Pure addition to an optional field on a Pydantic model with `response_model_exclude_none=True` semantics — existing clients that don't read `filename` see no change.
- No changes to URL generation, authentication, transcode logic, or meta / catalog endpoints.
- No new dependencies.
- No schema/config changes.

## Testing

Validated on a self-hosted Plexio instance running this branch against a real Plex server:
- `behaviorHints.filename` now matches the `description` filename on all three stream types
- Existing description formatting unchanged
- Stream URLs unchanged
- Existing clients (Stremio desktop, Nuvio, Omni) all continue to play streams normally